### PR TITLE
Update RepositoryContract.php

### DIFF
--- a/src/Repository/RepositoryContract.php
+++ b/src/Repository/RepositoryContract.php
@@ -35,7 +35,7 @@ interface RepositoryContract
 
     public function limit($limit);
 
-    public function orderBy($column, $value);
+    public function orderBy($column, $direction = 'asc')
 
     public function where($column, $value, $operator = '=');
 


### PR DESCRIPTION
Method 'JasonGuru\LaravelMakeRepository\Repository\BaseRepository::orderBy()' is not compatible with method 'JasonGuru\LaravelMakeRepository\Repository\RepositoryContract::orderBy()'.